### PR TITLE
fix: fix ShardingDatastore creation

### DIFF
--- a/test/sharding.spec.js
+++ b/test/sharding.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const { expect, assert } = require('aegir/utils/chai')
+const { expect } = require('aegir/utils/chai')
 const { Key, MemoryDatastore, utils: { utf8Decoder, utf8Encoder } } = require('interface-datastore')
 
 const ShardingStore = require('../src').ShardingDatastore
@@ -11,36 +11,38 @@ describe('ShardingStore', () => {
   it('create', async () => {
     const ms = new MemoryDatastore()
     const shard = new sh.NextToLast(2)
-    await ShardingStore.create(ms, shard)
-    const res = await Promise.all([ms.get(new Key(sh.SHARDING_FN)), ms.get(new Key(sh.README_FN))])
+    const store = new ShardingStore(ms, shard)
+    await store.open()
+    const res = await Promise.all([
+      ms.get(new Key(sh.SHARDING_FN)),
+      ms.get(new Key(sh.README_FN))
+    ])
     expect(utf8Decoder.decode(res[0])).to.eql(shard.toString() + '\n')
     expect(utf8Decoder.decode(res[1])).to.eql(sh.readme)
   })
 
   it('open - empty', async () => {
     const ms = new MemoryDatastore()
-    try {
-      await ShardingStore.open(ms)
-      assert(false, 'Failed to throw error on ShardStore.open')
-    } catch (err) {
-      expect(err.code).to.equal('ERR_NOT_FOUND')
-    }
+    // @ts-expect-error
+    const store = new ShardingStore(ms)
+    expect(store.open())
+      .to.eventually.be.rejected()
+      .with.property('code', 'ERR_NOT_FOUND')
   })
 
   it('open - existing', async () => {
     const ms = new MemoryDatastore()
     const shard = new sh.NextToLast(2)
+    const store = new ShardingStore(ms, shard)
 
-    await ShardingStore.create(ms, shard)
-    await ShardingStore.open(ms)
+    expect(store.open()).to.eventually.be.fulfilled()
   })
 
   it('basics', async () => {
     const ms = new MemoryDatastore()
     const shard = new sh.NextToLast(2)
-    const store = await ShardingStore.createOrOpen(ms, shard)
-    expect(store).to.exist()
-    await ShardingStore.createOrOpen(ms, shard)
+    const store = new ShardingStore(ms, shard)
+    await store.open()
     await store.put(new Key('hello'), utf8Encoder.encode('test'))
     const res = await ms.get(new Key('ll').child(new Key('hello')))
     expect(res).to.eql(utf8Encoder.encode('test'))
@@ -51,7 +53,7 @@ describe('ShardingStore', () => {
     require('interface-datastore/src/tests')({
       setup () {
         const shard = new sh.NextToLast(2)
-        return ShardingStore.createOrOpen(new MemoryDatastore(), shard)
+        return new ShardingStore(new MemoryDatastore(), shard)
       },
       teardown () { }
     })


### PR DESCRIPTION
This makes the ShardingDatastore work like the other datastore, where we can just do `const store = new Datastore()` and `await store.open()` without the need of extra static methods.

The old static methods should work as expected they are deprecated now we can make a breaking change and remove them all together. What do you think ?