### PR TITLE
feat: split .query into .query and .queryKeys

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "interface-datastore": "ipfs/interface-datastore#feat/split-query-into-query-and-query-keys",
+    "interface-datastore": "^4.0.0",
     "it-filter": "^1.0.2",
     "it-map": "^1.0.5",
     "it-merge": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "it-filter": "^1.0.2",
     "it-map": "^1.0.5",
     "it-merge": "^1.0.1",
-    "it-take": "^1.0.1"
+    "it-take": "^1.0.1",
+    "uint8arrays": "^2.1.5"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,11 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "interface-datastore": "^3.0.1"
+    "interface-datastore": "ipfs/interface-datastore#feat/split-query-into-query-and-query-keys",
+    "it-filter": "^1.0.2",
+    "it-map": "^1.0.5",
+    "it-merge": "^1.0.1",
+    "it-take": "^1.0.1"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/src/keytransform.js
+++ b/src/keytransform.js
@@ -1,12 +1,14 @@
 'use strict'
 
-const { Adapter, utils } = require('interface-datastore')
-const map = utils.map
+const { Adapter } = require('interface-datastore')
+const map = require('it-map')
+
 /**
  * @typedef {import('interface-datastore').Datastore} Datastore
  * @typedef {import('interface-datastore').Options} Options
  * @typedef {import('interface-datastore').Batch} Batch
  * @typedef {import('interface-datastore').Query} Query
+ * @typedef {import('interface-datastore').KeyQuery} KeyQuery
  * @typedef {import('interface-datastore').Key} Key
  * @typedef {import('./types').KeyTransform} KeyTransform
  */
@@ -90,9 +92,21 @@ class KeyTransformDatastore extends Adapter {
    * @param {Options} [options]
    */
   query (q, options) {
-    return map(this.child.query(q, options), e => {
-      e.key = this.transform.invert(e.key)
-      return e
+    return map(this.child.query(q, options), ({ key, value }) => {
+      return {
+        key: this.transform.invert(key),
+        value
+      }
+    })
+  }
+
+  /**
+   * @param {KeyQuery} q
+   * @param {Options} [options]
+   */
+  queryKeys (q, options) {
+    return map(this.child.queryKeys(q, options), key => {
+      return this.transform.invert(key)
     })
   }
 

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -5,6 +5,7 @@ const KeytransformDatastore = require('./keytransform')
 /**
  * @typedef {import('interface-datastore').Datastore} Datastore
  * @typedef {import('interface-datastore').Query} Query
+ * @typedef {import('interface-datastore').KeyQuery} KeyQuery
  * @typedef {import('interface-datastore').Options} Options
  * @typedef {import('interface-datastore').Batch} Batch
  * @typedef {import('./types').KeyTransform} KeyTransform
@@ -56,6 +57,19 @@ class NamespaceDatastore extends KeytransformDatastore {
       }))
     }
     return super.query(q, options)
+  }
+
+  /**
+   * @param {KeyQuery} q
+   * @param {Options} [options]
+   */
+  queryKeys (q, options) {
+    if (q.prefix && this.prefix.toString() !== '/') {
+      return super.queryKeys(Object.assign({}, q, {
+        prefix: this.prefix.child(new Key(q.prefix)).toString()
+      }))
+    }
+    return super.queryKeys(q, options)
   }
 }
 

--- a/src/shard.js
+++ b/src/shard.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Key, utils: { utf8Decoder } } = require('interface-datastore')
+const { Key } = require('interface-datastore')
 const readme = require('./shard-readme')
 
 /**
@@ -149,7 +149,7 @@ const readShardFun = async (path, store) => {
   // @ts-ignore
   const get = typeof store.getRaw === 'function' ? store.getRaw.bind(store) : store.get.bind(store)
   const res = await get(key)
-  return parseShardFun(utf8Decoder.decode(res || '').trim())
+  return parseShardFun(new TextDecoder().decode(res || '').trim())
 }
 
 module.exports = {

--- a/src/tiered.js
+++ b/src/tiered.js
@@ -121,6 +121,14 @@ class TieredDatastore extends Adapter {
   query (q, options) {
     return this.stores[this.stores.length - 1].query(q, options)
   }
+
+  /**
+   * @param {KeyQuery} q
+   * @param {Options} [options]
+   */
+  queryKeys (q, options) {
+    return this.stores[this.stores.length - 1].queryKeys(q, options)
+  }
 }
 
 module.exports = TieredDatastore

--- a/src/tiered.js
+++ b/src/tiered.js
@@ -7,6 +7,7 @@ const log = require('debug')('datastore:core:tiered')
  * @typedef {import('interface-datastore').Options} Options
  * @typedef {import('interface-datastore').Batch} Batch
  * @typedef {import('interface-datastore').Query} Query
+ * @typedef {import('interface-datastore').KeyQuery} KeyQuery
  * @typedef {import('interface-datastore').Key} Key
  */
 

--- a/test/mount.spec.js
+++ b/test/mount.spec.js
@@ -4,14 +4,15 @@
 
 const { expect, assert } = require('aegir/utils/chai')
 const all = require('it-all')
-const { Key, MemoryDatastore, utils: { utf8Encoder } } = require('interface-datastore')
+const { Key, MemoryDatastore } = require('interface-datastore')
 const MountStore = require('../src').MountDatastore
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 describe('MountStore', () => {
   it('put - no mount', async () => {
     const m = new MountStore([])
     try {
-      await m.put(new Key('hello'), utf8Encoder.encode('foo'))
+      await m.put(new Key('hello'), uint8ArrayFromString('foo'))
       assert(false, 'Failed to throw error on no mount')
     } catch (err) {
       expect(err).to.be.an('Error')
@@ -24,7 +25,7 @@ describe('MountStore', () => {
       prefix: new Key('cool')
     }])
     try {
-      await m.put(new Key('/fail/hello'), utf8Encoder.encode('foo'))
+      await m.put(new Key('/fail/hello'), uint8ArrayFromString('foo'))
       assert(false, 'Failed to throw error on wrong mount')
     } catch (err) {
       expect(err).to.be.an('Error')
@@ -38,7 +39,7 @@ describe('MountStore', () => {
       prefix: new Key('cool')
     }])
 
-    const val = utf8Encoder.encode('hello')
+    const val = uint8ArrayFromString('hello')
     await m.put(new Key('/cool/hello'), val)
     const res = await mds.get(new Key('/hello'))
     expect(res).to.eql(val)
@@ -51,7 +52,7 @@ describe('MountStore', () => {
       prefix: new Key('cool')
     }])
 
-    const val = utf8Encoder.encode('hello')
+    const val = uint8ArrayFromString('hello')
     await mds.put(new Key('/hello'), val)
     const res = await m.get(new Key('/cool/hello'))
     expect(res).to.eql(val)
@@ -64,7 +65,7 @@ describe('MountStore', () => {
       prefix: new Key('cool')
     }])
 
-    const val = utf8Encoder.encode('hello')
+    const val = uint8ArrayFromString('hello')
     await mds.put(new Key('/hello'), val)
     const exists = await m.has(new Key('/cool/hello'))
     expect(exists).to.eql(true)
@@ -77,7 +78,7 @@ describe('MountStore', () => {
       prefix: new Key('cool')
     }])
 
-    const val = utf8Encoder.encode('hello')
+    const val = uint8ArrayFromString('hello')
     await m.put(new Key('/cool/hello'), val)
     await m.delete(new Key('/cool/hello'))
     let exists = await m.has(new Key('/cool/hello'))
@@ -93,7 +94,7 @@ describe('MountStore', () => {
       prefix: new Key('cool')
     }])
 
-    const val = utf8Encoder.encode('hello')
+    const val = uint8ArrayFromString('hello')
     await m.put(new Key('/cool/hello'), val)
     const res = await all(m.query({ prefix: '/cool' }))
     expect(res).to.eql([{ key: new Key('/cool/hello'), value: val }])

--- a/test/namespace.spec.js
+++ b/test/namespace.spec.js
@@ -2,9 +2,10 @@
 'use strict'
 
 const { expect } = require('aegir/utils/chai')
-const { Key, MemoryDatastore, utils: { utf8Encoder } } = require('interface-datastore')
+const { Key, MemoryDatastore } = require('interface-datastore')
 const NamespaceStore = require('../src/').NamespaceDatastore
 const all = require('it-all')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 describe('KeyTransformDatastore', () => {
   const prefixes = [
@@ -24,7 +25,7 @@ describe('KeyTransformDatastore', () => {
       'foo/bar/baz/barb'
     ].map((s) => new Key(s))
 
-    await Promise.all(keys.map(key => store.put(key, utf8Encoder.encode(key.toString()))))
+    await Promise.all(keys.map(key => store.put(key, uint8ArrayFromString(key.toString()))))
     const nResults = Promise.all(keys.map((key) => store.get(key)))
     const mResults = Promise.all(keys.map((key) => mStore.get(new Key(prefix).child(key))))
     const results = await Promise.all([nResults, mResults])

--- a/test/sharding.spec.js
+++ b/test/sharding.spec.js
@@ -2,7 +2,9 @@
 'use strict'
 
 const { expect } = require('aegir/utils/chai')
-const { Key, MemoryDatastore, utils: { utf8Decoder, utf8Encoder } } = require('interface-datastore')
+const { Key, MemoryDatastore } = require('interface-datastore')
+const uint8ArrayFromString = require('uint8arrays/from-string')
+const uint8ArrayToString = require('uint8arrays/to-string')
 
 const ShardingStore = require('../src').ShardingDatastore
 const sh = require('../src').shard
@@ -17,8 +19,8 @@ describe('ShardingStore', () => {
       ms.get(new Key(sh.SHARDING_FN)),
       ms.get(new Key(sh.README_FN))
     ])
-    expect(utf8Decoder.decode(res[0])).to.eql(shard.toString() + '\n')
-    expect(utf8Decoder.decode(res[1])).to.eql(sh.readme)
+    expect(uint8ArrayToString(res[0])).to.eql(shard.toString() + '\n')
+    expect(uint8ArrayToString(res[1])).to.eql(sh.readme)
   })
 
   it('open - empty', () => {
@@ -43,9 +45,9 @@ describe('ShardingStore', () => {
     const shard = new sh.NextToLast(2)
     const store = new ShardingStore(ms, shard)
     await store.open()
-    await store.put(new Key('hello'), utf8Encoder.encode('test'))
+    await store.put(new Key('hello'), uint8ArrayFromString('test'))
     const res = await ms.get(new Key('ll').child(new Key('hello')))
-    expect(res).to.eql(utf8Encoder.encode('test'))
+    expect(res).to.eql(uint8ArrayFromString('test'))
   })
 
   describe('interface-datastore', () => {

--- a/test/tiered.spec.js
+++ b/test/tiered.spec.js
@@ -2,8 +2,9 @@
 'use strict'
 
 const { expect } = require('aegir/utils/chai')
-const { Key, MemoryDatastore, utils: { utf8Encoder } } = require('interface-datastore')
+const { Key, MemoryDatastore } = require('interface-datastore')
 const { TieredDatastore } = require('../src')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 /**
  * @typedef {import('interface-datastore/dist/src/types').Datastore} Datastore
  */
@@ -22,7 +23,7 @@ describe('Tiered', () => {
 
     it('put', async () => {
       const k = new Key('hello')
-      const v = utf8Encoder.encode('world')
+      const v = uint8ArrayFromString('world')
       await store.put(k, v)
       const res = await Promise.all([ms[0].get(k), ms[1].get(k)])
       res.forEach((val) => {
@@ -32,7 +33,7 @@ describe('Tiered', () => {
 
     it('get and has, where available', async () => {
       const k = new Key('hello')
-      const v = utf8Encoder.encode('world')
+      const v = uint8ArrayFromString('world')
       await ms[1].put(k, v)
       const val = await store.get(k)
       expect(val).to.be.eql(v)
@@ -46,7 +47,7 @@ describe('Tiered', () => {
 
     it('has and delete', async () => {
       const k = new Key('hello')
-      const v = utf8Encoder.encode('world')
+      const v = uint8ArrayFromString('world')
       await store.put(k, v)
       let res = await Promise.all([ms[0].has(k), ms[1].has(k)])
       expect(res).to.be.eql([true, true])

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
-    "extends": "./node_modules/aegir/src/config/tsconfig.aegir.json",
+    "extends": "aegir/src/config/tsconfig.aegir.json",
     "compilerOptions": {
         "outDir": "dist"
     },
     "include": [
-      "test", // remove this line if you don't want to type-check tests
+      "test",
       "src"
     ]
 }


### PR DESCRIPTION
Applies changes from ipfs/interface-datastore/pull/87 and removes
redundant utilities.

Depends on:

- [x] https://github.com/ipfs/interface-datastore/pull/87