### PR TITLE
fix: use streaming methods where possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "it-filter": "^1.0.2",
     "it-map": "^1.0.5",
     "it-merge": "^1.0.1",
+    "it-pipe": "^1.1.0",
+    "it-pushable": "^1.4.2",
     "it-take": "^1.0.1",
     "uint8arrays": "^2.1.5"
   },

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "debug": "^4.1.1",
     "interface-datastore": "^5.1.1",
+    "it-drain": "^1.0.4",
     "it-filter": "^1.0.2",
     "it-map": "^1.0.5",
     "it-merge": "^1.0.1",

--- a/src/mount.js
+++ b/src/mount.js
@@ -23,11 +23,6 @@ const Keytransform = require('./keytransform')
  */
 
 /**
- * @template TEntry
- * @typedef {import('./types').AwaitIterable<TEntry>} AwaitIterable
- */
-
-/**
  * A datastore that can combine multiple stores inside various
  * key prefixes
  *

--- a/src/sharding.js
+++ b/src/sharding.js
@@ -22,7 +22,12 @@ const shardReadmeKey = new Key(sh.README_FN)
  */
 /**
  * @template TValue
- * @typedef {import('./types').Await<TValue> } Await
+ * @typedef {import('interface-store').Await<TValue> } Await
+ */
+
+/**
+ * @template TEntry
+ * @typedef {import('interface-store').AwaitIterable<TEntry>} AwaitIterable
  */
 
 /**
@@ -160,6 +165,33 @@ class ShardingDatastore extends Adapter {
    */
   delete (key, options) {
     return this.child.delete(key, options)
+  }
+
+  /**
+   * @param {AwaitIterable<Pair>} source
+   * @param {Options} [options]
+   * @returns {AsyncIterable<Pair>}
+   */
+  async * putMany (source, options = {}) {
+    yield * this.child.putMany(source, options)
+  }
+
+  /**
+   * @param {AwaitIterable<Key>} source
+   * @param {Options} [options]
+   * @returns {AsyncIterable<Uint8Array>}
+   */
+  async * getMany (source, options = {}) {
+    yield * this.child.getMany(source, options)
+  }
+
+  /**
+   * @param {AwaitIterable<Key>} source
+   * @param {Options} [options]
+   * @returns {AsyncIterable<Key>}
+   */
+  async * deleteMany (source, options = {}) {
+    yield * this.child.deleteMany(source, options)
   }
 
   batch () {

--- a/src/tiered.js
+++ b/src/tiered.js
@@ -145,7 +145,7 @@ class TieredDatastore extends Adapter {
 
       drain(store.deleteMany(source, options))
         .catch(err => {
-          // store threw while putting, make sure we bubble the error up
+          // store threw while deleting, make sure we bubble the error up
           error = err
         })
 


### PR DESCRIPTION
The base adapter class calls `.put` repeatedly when `.putMany` is invoked
in order to reduce the number of methods a datastore has to implement to
be compatible with the datastore interface.

This hurts performance where datastores wrap other datastores that can
take advantage of the streaming methods to exectute certain operations in
parallel.

The change here is to call streaming methods from streaming methods where
it makes sense to do so, instead of letting the adapter class convert
streaming method invocations into serial method invocations.