### PR TITLE
fix: do not strip prefixes for MountDatastores

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
   - Keytransform: [`src/keytransform`](src/keytransform.js)
   - Sharding: [`src/sharding`](src/sharding.js)
   - Tiered: [`src/tiered`](src/tirered.js)
-  - Namespace: [`src/tiered`](src/namespace.js)
+  - Namespace: [`src/namespace`](src/namespace.js)
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "homepage": "https://github.com/ipfs/js-datastore-core#readme",
   "devDependencies": {
     "@types/debug": "^4.1.5",
-    "aegir": "^35.0.2",
+    "aegir": "^36.1.3",
     "interface-datastore-tests": "^2.0.3",
     "it-all": "^1.0.4",
     "rimraf": "^3.0.2",

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -16,7 +16,6 @@ import { KeyTransformDatastore } from './keytransform.js'
  * For example, if the prefix is `new Key(/hello)` a call
  * to `store.put(new Key('/world'), mydata)` would store the data under
  * `/hello/world`.
- *
  */
 export class NamespaceDatastore extends KeyTransformDatastore {
   /**
@@ -40,33 +39,5 @@ export class NamespaceDatastore extends KeyTransformDatastore {
         return new Key(key.toString().slice(prefix.toString().length), false)
       }
     })
-
-    this.prefix = prefix
-  }
-
-  /**
-   * @param {Query} q
-   * @param {Options} [options]
-   */
-  query (q, options) {
-    if (q.prefix && this.prefix.toString() !== '/') {
-      return super.query(Object.assign({}, q, {
-        prefix: this.prefix.child(new Key(q.prefix)).toString()
-      }))
-    }
-    return super.query(q, options)
-  }
-
-  /**
-   * @param {KeyQuery} q
-   * @param {Options} [options]
-   */
-  queryKeys (q, options) {
-    if (q.prefix && this.prefix.toString() !== '/') {
-      return super.queryKeys(Object.assign({}, q, {
-        prefix: this.prefix.child(new Key(q.prefix)).toString()
-      }))
-    }
-    return super.queryKeys(q, options)
   }
 }

--- a/src/sharding.js
+++ b/src/sharding.js
@@ -208,57 +208,15 @@ export class ShardingDatastore extends BaseDatastore {
    * @param {Options} [options]
    */
   query (q, options) {
+    /** @type {Query} */
     const tq = {
-      offset: q.offset,
-      limit: q.limit,
-      /** @type {QueryOrder[]} */
-      orders: [],
-      /** @type {QueryFilter[]} */
+      ...q,
       filters: [
         /** @type {QueryFilter} */
-        e => e.key.toString() !== shardKey.toString(),
+        ({ key }) => key.toString() !== shardKey.toString(),
         /** @type {QueryFilter} */
-        e => e.key.toString() !== shardReadmeKey.toString()
-      ]
-    }
-
-    const { prefix } = q
-    if (prefix != null) {
-      tq.filters.push((e) => {
-        return this._invertKey(e.key).toString().startsWith(prefix)
-      })
-    }
-
-    if (q.filters != null) {
-      const filters = q.filters.map(f => {
-        /** @type {QueryFilter} */
-        const filter = ({ key, value }) => {
-          return f({
-            key: this._invertKey(key),
-            value
-          })
-        }
-
-        return filter
-      })
-      tq.filters = tq.filters.concat(filters)
-    }
-
-    if (q.orders != null) {
-      tq.orders = q.orders.map(o => {
-        /** @type {QueryOrder} */
-        const order = (a, b) => {
-          return o({
-            key: this._invertKey(a.key),
-            value: a.value
-          }, {
-            key: this._invertKey(b.key),
-            value: b.value
-          })
-        }
-
-        return order
-      })
+        ({ key }) => key.toString() !== shardReadmeKey.toString()
+      ].concat(q.filters || [])
     }
 
     return this.child.query(tq, options)
@@ -269,46 +227,15 @@ export class ShardingDatastore extends BaseDatastore {
    * @param {Options} [options]
    */
   queryKeys (q, options) {
+    /** @type {KeyQuery} */
     const tq = {
-      offset: q.offset,
-      limit: q.limit,
-      /** @type {KeyQueryOrder[]} */
-      orders: [],
-      /** @type {KeyQueryFilter[]} */
+      ...q,
       filters: [
         /** @type {KeyQueryFilter} */
         key => key.toString() !== shardKey.toString(),
         /** @type {KeyQueryFilter} */
         key => key.toString() !== shardReadmeKey.toString()
-      ]
-    }
-
-    const { prefix } = q
-    if (prefix != null) {
-      tq.filters.push((key) => {
-        return this._invertKey(key).toString().startsWith(prefix)
-      })
-    }
-
-    if (q.filters != null) {
-      const filters = q.filters.map(f => {
-        /** @type {KeyQueryFilter} */
-        const filter = (key) => {
-          return f(this._invertKey(key))
-        }
-
-        return filter
-      })
-      tq.filters = tq.filters.concat(filters)
-    }
-
-    if (q.orders != null) {
-      tq.orders = q.orders.map(o => {
-        /** @type {KeyQueryOrder} */
-        const order = (a, b) => o(this._invertKey(a), this._invertKey(b))
-
-        return order
-      })
+      ].concat(q.filters || [])
     }
 
     return this.child.queryKeys(tq, options)

--- a/test/mount.spec.js
+++ b/test/mount.spec.js
@@ -8,6 +8,25 @@ import { MemoryDatastore } from '../src/memory.js'
 import { MountDatastore } from '../src/mount.js'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { interfaceDatastoreTests } from 'interface-datastore-tests'
+import { KeyTransformDatastore } from '../src/keytransform.js'
+
+/**
+ * @param {import('interface-datastore').Datastore} datastore
+ * @param {Key} prefix
+ */
+const stripPrefixDatastore = (datastore, prefix) => {
+  return new KeyTransformDatastore(
+    datastore, {
+      convert: (key) => {
+        if (!prefix.isAncestorOf(key)) {
+          throw new Error(`Expected prefix: (${prefix.toString()}) in key: ${key.toString()}`)
+        }
+
+        return Key.withNamespaces(key.namespaces().slice(prefix.namespaces().length))
+      },
+      invert: (key) => Key.withNamespaces([...prefix.namespaces(), ...key.namespaces()])
+    })
+}
 
 describe('MountDatastore', () => {
   it('put - no mount', async () => {
@@ -22,7 +41,7 @@ describe('MountDatastore', () => {
 
   it('put - wrong mount', async () => {
     const m = new MountDatastore([{
-      datastore: new MemoryDatastore(),
+      datastore: stripPrefixDatastore(new MemoryDatastore(), new Key('cool')),
       prefix: new Key('cool')
     }])
     try {
@@ -36,7 +55,7 @@ describe('MountDatastore', () => {
   it('put', async () => {
     const mds = new MemoryDatastore()
     const m = new MountDatastore([{
-      datastore: mds,
+      datastore: stripPrefixDatastore(mds, new Key('cool')),
       prefix: new Key('cool')
     }])
 
@@ -49,7 +68,7 @@ describe('MountDatastore', () => {
   it('get', async () => {
     const mds = new MemoryDatastore()
     const m = new MountDatastore([{
-      datastore: mds,
+      datastore: stripPrefixDatastore(mds, new Key('cool')),
       prefix: new Key('cool')
     }])
 
@@ -62,7 +81,7 @@ describe('MountDatastore', () => {
   it('has', async () => {
     const mds = new MemoryDatastore()
     const m = new MountDatastore([{
-      datastore: mds,
+      datastore: stripPrefixDatastore(mds, new Key('cool')),
       prefix: new Key('cool')
     }])
 
@@ -75,7 +94,7 @@ describe('MountDatastore', () => {
   it('delete', async () => {
     const mds = new MemoryDatastore()
     const m = new MountDatastore([{
-      datastore: mds,
+      datastore: stripPrefixDatastore(mds, new Key('cool')),
       prefix: new Key('cool')
     }])
 
@@ -91,7 +110,7 @@ describe('MountDatastore', () => {
   it('query simple', async () => {
     const mds = new MemoryDatastore()
     const m = new MountDatastore([{
-      datastore: mds,
+      datastore: stripPrefixDatastore(mds, new Key('cool')),
       prefix: new Key('cool')
     }])
 

--- a/test/namespace.spec.js
+++ b/test/namespace.spec.js
@@ -8,7 +8,7 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { NamespaceDatastore } from '../src/namespace.js'
 import { interfaceDatastoreTests } from 'interface-datastore-tests'
 
-describe('KeyTransformDatastore', () => {
+describe('NamespaceDatastore', () => {
   const prefixes = [
     'abc',
     ''


### PR DESCRIPTION
If you have a mount datastore:

```js
const d = new MountDatastore([{
  datastore: foo,
  prefix: new Key('/bar')
}])
```

`d.put(new Key('/bar/baz'), val)` results in `foo.put(new Key('/baz'), val)`.

This PR changes the default behaviour to `foo.put(new Key('/bar/baz'), val)`.

If you need the old behaviour, use a `KeyTransformDatastore` to strip the prefix - see [stripPrefixDatastore](https://github.com/ipfs/js-datastore-core/blob/master/test/mount.spec.js#L17) in the MountDatastore tests for an example.

BREAKING CHANGE: key prefixes are no longer stripped by MountDatastore