### PR TITLE
fix: fix generated types to missing import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,13 +9,8 @@ export { MountDatastore } from './mount.js'
 export { TieredDatastore } from './tiered.js'
 export { NamespaceDatastore } from './namespace.js'
 
-export const Errors = {
-  ...ErrorsImport
-}
-
-export const shard = {
-  ...ShardImport
-}
+export const Errors = ErrorsImport
+export const shard = ShardImport
 
 /**
  * @typedef {import("./types").Shard } Shard


### PR DESCRIPTION
**Motivation**
Got this error when using this in lodestar

```
@chainsafe/lodestar: $ tsc -p tsconfig.build.json
@chainsafe/lodestar: ../../node_modules/datastore-core/types/src/index.d.ts:20:23 - error TS2304: Cannot find name 'ShardImport'.
@chainsafe/lodestar: 20     ShardBase: typeof ShardImport.ShardBase;
@chainsafe/lodestar:                          ~~~~~~~~~~~
@chainsafe/lodestar: ../../node_modules/datastore-core/types/src/index.d.ts:21:20 - error TS2304: Cannot find name 'ShardImport'.
@chainsafe/lodestar: 21     Prefix: typeof ShardImport.Prefix;
@chainsafe/lodestar:                       ~~~~~~~~~~~
@chainsafe/lodestar: ../../node_modules/datastore-core/types/src/index.d.ts:22:20 - error TS2304: Cannot find name 'ShardImport'.
@chainsafe/lodestar: 22     Suffix: typeof ShardImport.Suffix;
@chainsafe/lodestar:                       ~~~~~~~~~~~
@chainsafe/lodestar: ../../node_modules/datastore-core/types/src/index.d.ts:23:24 - error TS2304: Cannot find name 'ShardImport'.
@chainsafe/lodestar: 23     NextToLast: typeof ShardImport.NextToLast;
@chainsafe/lodestar:                           ~~~~~~~~~~~
@chainsafe/lodestar: Found 4 errors.
@chainsafe/lodestar: error Command failed with exit code 2.
```

**Description**
+ change the way to generate shard types
+ close #85 