### PR TITLE
fix: pass options to tiered put

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,3 @@
-import * as ErrorsImport from './errors.js'
-import * as ShardImport from './shard.js'
-
 export { BaseDatastore } from './base.js'
 export { MemoryDatastore } from './memory.js'
 export { KeyTransformDatastore } from './keytransform.js'
@@ -9,8 +6,8 @@ export { MountDatastore } from './mount.js'
 export { TieredDatastore } from './tiered.js'
 export { NamespaceDatastore } from './namespace.js'
 
-export const Errors = ErrorsImport
-export const shard = ShardImport
+export * as Errors from './errors.js'
+export * as shard from './shard.js'
 
 /**
  * @typedef {import("./types").Shard } Shard

--- a/src/tiered.js
+++ b/src/tiered.js
@@ -49,10 +49,11 @@ export class TieredDatastore extends BaseDatastore {
   /**
    * @param {Key} key
    * @param {Uint8Array} value
+   * @param {Options} [options]
    */
-  async put (key, value) {
+  async put (key, value, options) {
     try {
-      await Promise.all(this.stores.map(store => store.put(key, value)))
+      await Promise.all(this.stores.map(store => store.put(key, value, options)))
     } catch (err) {
       throw Errors.dbWriteFailedError()
     }


### PR DESCRIPTION
Ensure we can abort put operations by passing options into the wrapped datastores.